### PR TITLE
add logging to container class

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -31,6 +31,28 @@ class Container
     protected $_currentRoute = null;
 
     /**
+     * Logger
+     *
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $_logger = null;
+
+    /**
+     * Class constructor
+     *
+     * Store the retrieved logger that implements the \Psr\Log\LoggerInterface
+     * to the class protected property.
+     *
+     * @param \Psr\Log\LoggerInterface $logger Logger object
+     */
+    public function __construct(\Psr\Log\LoggerInterface $logger)
+    {
+        $this->_logger = $logger;
+
+        $this->_logger->info("Route Container initialized");
+    }
+
+    /**
      * Add Route definition
      *
      * Add the retrieved Route to the internal Routes container array. If the
@@ -44,12 +66,19 @@ class Container
         if ($route->uri === ""
             || $route->method === ""
             || $route->action === null) {
+            $this->_logger->error("Route incomplete. Unable to add");
+            $this->_logger->debug("Incomplete Route", [$route]);
             throw new Exception\RouteIncompleteException(
                 "Retrieved Route is not complete and can not be stored"
             );
         }
 
         $this->_routes[] = $route;
+
+        $this->_logger->info(
+            "Route successfully added to Container",
+            ["uri" => $route->uri]
+        );
 
         return $this;
     }

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -38,6 +38,13 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     protected $_route = null;
 
     /**
+     * Logger Mock
+     *
+     * @var mocked object
+     */
+    protected $_logger = null;
+
+    /**
      * Prepare test
      *
      * Prepare a fresch container object for every test as well as a fresh Route
@@ -47,11 +54,13 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->_container = new Container;
+        $this->_logger = $this->getMock("\\Psr\\Log\\LoggerInterface");
+
+        $this->_container = new Container($this->_logger);
 
         $this->_route = $this->getMockBuilder("\\SlaxWeb\\Router\\Route")
             ->setMethods(null)
-            ->getMock();;
+            ->getMock();
         $this->_route->uri = "";
         $this->_route->method = "";
         $this->_route->action = null;
@@ -83,21 +92,31 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $route = clone $this->_route;
 
+        $logger = clone $this->_logger;
+        $logger->expects($this->once())
+            ->method("error");
+        $logger->expects($this->once())
+            ->method("debug");
+        $container = clone $this->_container;
         $this->specify(
             "Route definition incomplete",
-            function () use ($route) {
-                $this->_container->add($route);
+            function () use ($route, $container) {
+                $container->add($route);
             },
             ["throws" => "SlaxWeb\\Router\\Exception\\RouteIncompleteException"]
         );
 
-        $this->specify("Valid Route", function () use ($route) {
+        $logger = clone $this->_logger;
+        $logger->expects($this->once())
+            ->method("info");
+        $container = clone $this->_container;
+        $this->specify("Valid Route", function () use ($route, $container) {
             $route->uri = "~^uri$~";
             $route->method = "GET";
             $route->action = function () {
                 return true;
             };
-            $this->_container->add($route);
+            $container->add($route);
         });
     }
 

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -39,6 +39,13 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     protected $_route = null;
 
     /**
+     * Logger Mock
+     *
+     * @var mocked object
+     */
+    protected $_logger = null;
+
+    /**
      * Prepare test
      *
      * Prepare a fresch container object for every test as well as a fresh Route
@@ -48,9 +55,17 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->_container = new Container;
+        $this->_logger = $this->getMock("\\Psr\\Log\\LoggerInterface");
 
+        $this->_container = new Container($this->_logger);
+
+<<<<<<< Updated upstream
         $this->_route = m::mock("\\SlaxWeb\\Router\\Route")->makePartial();
+=======
+        $this->_route = $this->getMockBuilder("\\SlaxWeb\\Router\\Route")
+            ->setMethods(null)
+            ->getMock();
+>>>>>>> Stashed changes
         $this->_route->uri = "";
         $this->_route->method = "";
         $this->_route->action = null;
@@ -82,21 +97,31 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $route = clone $this->_route;
 
+        $logger = clone $this->_logger;
+        $logger->expects($this->once())
+            ->method("error");
+        $logger->expects($this->once())
+            ->method("debug");
+        $container = clone $this->_container;
         $this->specify(
             "Route definition incomplete",
-            function () use ($route) {
-                $this->_container->add($route);
+            function () use ($route, $container) {
+                $container->add($route);
             },
             ["throws" => "SlaxWeb\\Router\\Exception\\RouteIncompleteException"]
         );
 
-        $this->specify("Valid Route", function () use ($route) {
+        $logger = clone $this->_logger;
+        $logger->expects($this->once())
+            ->method("info");
+        $container = clone $this->_container;
+        $this->specify("Valid Route", function () use ($route, $container) {
             $route->uri = "~^uri$~";
             $route->method = "GET";
             $route->action = function () {
                 return true;
             };
-            $this->_container->add($route);
+            $container->add($route);
         });
     }
 


### PR DESCRIPTION
Added logging to container, no other class makes sense to log stuff from. Newer classes should introduce logging directly with their own implementations and not through this branch.
